### PR TITLE
lock to older swagger-editor image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swaggerapi/swagger-editor
+FROM swaggerapi/swagger-editor:v2.9.9
 
 USER 0
 


### PR DESCRIPTION
This will allow this container to build, helping other projects like https://github.com/bcgov/schoolbus build on OpenShift without failure.

Also delays need to deal with #2 right away.